### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,5 +103,9 @@ jobs:
 
     - name: Lint with clippy
       shell: bash
-      if: (matrix.rust_version == 'stable') && !contains(matrix.platform.options, '--no-default-features')
+      if: >
+        (matrix.rust_version == 'stable') && 
+        !contains(matrix.platform.target, 'ios') &&
+        !contains(matrix.platform.target, 'android') &&
+        !contains(matrix.platform.options, '--no-default-features')
       run: cargo clippy --all-targets --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES -- -Dwarnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           - { target: i686-unknown-linux-gnu,   os: ubuntu-latest,   }
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest,   }
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest, options: --no-default-features, features: x11 }
-          - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest, options: --no-default-features, features: wayland }
+          - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest, options: --no-default-features, features: "wayland,wayland-dlopen" }
           - { target: aarch64-linux-android,    os: ubuntu-latest, cmd: 'apk --', features: "android-native-activity" }
           - { target: x86_64-unknown-redox,     os: ubuntu-latest,   }
           - { target: x86_64-apple-darwin,      os: macos-latest,    }
@@ -84,9 +84,12 @@ jobs:
       shell: bash
       if: >
         !contains(matrix.platform.target, 'redox') &&
+        !contains(matrix.platform.target, 'ios') &&
+        !contains(matrix.platform.target, 'android') &&
         matrix.rust_version != '1.64.0'
       run: cargo $CMD test --no-run --verbose --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES
 
+    # TODO: Run tests on android/ios once rust-windowing/softbuffer#44 is resolved
     - name: Run tests
       shell: bash
       if: >
@@ -94,6 +97,7 @@ jobs:
         !contains(matrix.platform.target, 'ios') &&
         !contains(matrix.platform.target, 'wasm32') &&
         !contains(matrix.platform.target, 'redox') &&
+        !contains(matrix.platform.target, 'android') &&
         matrix.rust_version != '1.64.0'
       run: cargo $CMD test --verbose --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ softbuffer = { version = "0.2.0", default-features = false, features = ["x11"] }
 winit = { version = "0.28.3", default-features = false, features = ["x11"] }
 
 [features]
-default = ["x11", "wayland"]
+default = ["x11", "wayland", "wayland-dlopen"]
 x11 = ["winit/x11"]
 wayland = ["winit/wayland"]
 wayland-dlopen = ["winit/wayland-dlopen"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ winit = { version = "0.28.3", default-features = false, features = ["x11"] }
 default = ["x11", "wayland"]
 x11 = ["winit/x11"]
 wayland = ["winit/wayland"]
+wayland-dlopen = ["winit/wayland-dlopen"]
 android-native-activity = ["winit/android-native-activity"]
 android-game-activity = ["winit/android-game-activity"]
 


### PR DESCRIPTION
- Ignore tests on Android/iOS since `softbuffer` doesn't build there set, see rust-windowing/softbuffer#44 and rust-windowing/softbuffer#43
- Use dlopen on wayland platforms