### PR TITLE
Unseal the event constraint

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -36,7 +36,6 @@ use async_lock::Mutex as AsyncMutex;
 use futures_lite::{future, Stream};
 use slab::Slab;
 
-pub(crate) use __private::{EventSealed, Internal};
 use waiters::{Listener, RegisterResult, Waiters};
 
 /// An event handler.
@@ -90,7 +89,7 @@ struct Inner<T: Event> {
 }
 
 type DirectListener<T> =
-    Box<dyn FnMut(&mut <T as EventSealed>::Unique<'_>) -> DirectFuture + Send + 'static>;
+    Box<dyn FnMut(&mut <T as Event>::Unique<'_>) -> DirectFuture + Send + 'static>;
 type DirectFuture = Pin<Box<dyn Future<Output = bool> + Send + 'static>>;
 
 /// The state of the hold.
@@ -134,7 +133,7 @@ impl<T: Event> Handler<T> {
             None => return,
         };
 
-        let clonable = T::downgrade(event, Internal::new());
+        let clonable = T::downgrade(event);
         inner
             .once
             .lock()
@@ -172,7 +171,7 @@ impl<T: Event> Handler<T> {
                 // There should be no hold state; create one.
                 debug_assert!(hold_state.is_none());
                 *hold_state = Some(HoldState {
-                    data: T::downgrade(event, Internal::new()),
+                    data: T::downgrade(event),
                     gen,
                     waiters_left: held,
                     waker: Some(waker),
@@ -534,34 +533,18 @@ impl<T: Event> Drop for HeldGuard<'_, '_, T> {
 /// The type of event that can be sent over a [`Handler`].
 ///
 /// This type is sealed and cannot be implemented outside of this crate.
-pub trait Event: EventSealed {}
+pub trait Event {
+    type Clonable: Clone + 'static;
+    type Unique<'a>: 'a;
 
-impl<T: Clone + 'static> Event for T {}
+    fn downgrade(unique: &mut Self::Unique<'_>) -> Self::Clonable;
+}
 
-mod __private {
-    #[doc(hidden)]
-    pub struct Internal(());
+impl<T: Clone + 'static> Event for T {
+    type Clonable = T;
+    type Unique<'a> = T;
 
-    impl Internal {
-        pub(crate) fn new() -> Self {
-            Internal(())
-        }
-    }
-
-    #[doc(hidden)]
-    pub trait EventSealed {
-        type Clonable: Clone + 'static;
-        type Unique<'a>: 'a;
-
-        fn downgrade(unique: &mut Self::Unique<'_>, i: Internal) -> Self::Clonable;
-    }
-
-    impl<T: Clone + 'static> EventSealed for T {
-        type Clonable = T;
-        type Unique<'a> = T;
-
-        fn downgrade(unique: &mut Self::Unique<'_>, _: Internal) -> Self::Clonable {
-            unique.clone()
-        }
+    fn downgrade(unique: &mut Self::Unique<'_>) -> Self::Clonable {
+        unique.clone()
     }
 }

--- a/src/window/registration.rs
+++ b/src/window/registration.rs
@@ -98,18 +98,17 @@ pub struct ScaleFactorChanged {
     pub new_inner_size: PhysicalSize<u32>,
 }
 
-impl crate::handler::EventSealed for ScaleFactor {
+impl Event for ScaleFactor {
     type Clonable = ScaleFactorChanged;
     type Unique<'a> = ScaleFactorChanging<'a>;
 
-    fn downgrade(unique: &mut Self::Unique<'_>, _: crate::handler::Internal) -> Self::Clonable {
+    fn downgrade(unique: &mut Self::Unique<'_>) -> Self::Clonable {
         ScaleFactorChanged {
             scale_factor: unique.scale_factor,
             new_inner_size: *unique.new_inner_size,
         }
     }
 }
-impl Event for ScaleFactor {}
 
 pub(crate) struct Registration {
     /// `RedrawRequested`


### PR DESCRIPTION
Makes it easier to external crates to manipulate events